### PR TITLE
Fixes to GetToolFramework.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+include/*.h
+lib/*.so
+UserTools/*/*.o
+DataModel/*.o
+Dependencies
+main
+*.d
+*.root
+*~

--- a/GetToolFramework.sh
+++ b/GetToolFramework.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-init=1
 toolframework=1
 final=1
 
@@ -8,17 +7,12 @@ while [ ! $# -eq 0 ]
 do
     case "$1" in
 	--help | -h)
-	    helpmenu
+	    echo "This script should be run once after initially cloning the ToolFrameworkApplication repository. It retrieves the ToolFrameworkCore repository that provides the core framework on which your application will be built."
 	    exit
 	    ;;
 	
-	--no_init )
-	     echo "Installing Applicaiton without creating Dependancy Folder"
-	    init=0;
-	    ;;
-
 	--no_toolframework )
-	    echo "Installing dependancies without ToolFramework"
+	    echo "Installing dependencies without ToolFramework"
 	    toolframework=0
 	    ;;
 
@@ -38,13 +32,9 @@ do
     shift
 done
 
-if [ $init -eq 1 ]
-then
-    
-    mkdir Dependancies
-fi
+mkdir -p Dependencies
 
-cd Dependancies
+cd Dependencies
 
 if [ $toolframework -eq 1 ]
 then

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-Dependancies=Dependancies
+Dependencies=Dependencies
 
 CXXFLAGS=  -fPIC -O3 -Wpedantic 
 
@@ -20,24 +20,24 @@ main: src/main.cpp lib/libStore.so lib/libLogging.so lib/libToolChain.so | lib/l
 	@echo -e "\e[38;5;214m\n*************** Making " $@ "****************\e[0m"
 	g++ $(CXXFLAGS) src/main.cpp -o main -I include -L lib -lStore -lMyTools -lToolChain -lDataModel -lLogging  -lpthread $(DataModelInclude) $(MyToolsInclude) $(ZMQLib) 
 
-lib/libStore.so: $(Dependancies)/ToolFrameworkCore/src/Store/*
-	cd $(Dependancies)/ToolFrameworkCore && $(MAKE) lib/libStore.so
+lib/libStore.so: $(Dependencies)/ToolFrameworkCore/src/Store/*
+	cd $(Dependencies)/ToolFrameworkCore && $(MAKE) lib/libStore.so
 	@echo -e "\e[38;5;118m\n*************** Copying " $@ "****************\e[0m"
-	cp $(Dependancies)/ToolFrameworkCore/src/Store/*.h include/
-	cp $(Dependancies)/ToolFrameworkCore/lib/libStore.so lib/
+	cp $(Dependencies)/ToolFrameworkCore/src/Store/*.h include/
+	cp $(Dependencies)/ToolFrameworkCore/lib/libStore.so lib/
 
-include/Tool.h:  $(Dependancies)/ToolFrameworkCore/src/Tool/Tool.h
+include/Tool.h:  $(Dependencies)/ToolFrameworkCore/src/Tool/Tool.h
 	@echo -e "\e[38;5;118m\n*************** Copying " $@ "****************\e[0m"
-	cp $(Dependancies)/ToolFrameworkCore/src/Tool/Tool.h include/
+	cp $(Dependencies)/ToolFrameworkCore/src/Tool/Tool.h include/
 	cp UserTools/*.h include/
 	cp UserTools/*/*.h include/
 	cp DataModel/*.h include/
 
-lib/libToolChain.so: $(Dependancies)/ToolFrameworkCore/src/ToolChain/* | lib/libLogging.so lib/libStore.so lib/libMyTools.so lib/libLogging.so lib/libDataModel.so
+lib/libToolChain.so: $(Dependencies)/ToolFrameworkCore/src/ToolChain/* | lib/libLogging.so lib/libStore.so lib/libMyTools.so lib/libLogging.so lib/libDataModel.so
 	@echo -e "\e[38;5;226m\n*************** Making " $@ "****************\e[0m"
-	cp $(Dependancies)/ToolFrameworkCore/UserTools/Factory/*.h include/
-	cp $(Dependancies)/ToolFrameworkCore/src/ToolChain/*.h include/
-	g++ $(CXXFLAGS) -shared $(Dependancies)/ToolFrameworkCore/src/ToolChain/ToolChain.cpp -I include -lpthread -L lib -lStore -lDataModel -lLogging -lMyTools -o lib/libToolChain.so $(DataModelInclude) $(DataModelib) $(MyToolsInclude) $(MyToolsLib)
+	cp $(Dependencies)/ToolFrameworkCore/UserTools/Factory/*.h include/
+	cp $(Dependencies)/ToolFrameworkCore/src/ToolChain/*.h include/
+	g++ $(CXXFLAGS) -shared $(Dependencies)/ToolFrameworkCore/src/ToolChain/ToolChain.cpp -I include -lpthread -L lib -lStore -lDataModel -lLogging -lMyTools -o lib/libToolChain.so $(DataModelInclude) $(DataModelib) $(MyToolsInclude) $(MyToolsLib)
 
 
 clean: 
@@ -63,11 +63,11 @@ lib/libMyTools.so: UserTools/*/* UserTools/* lib/libStore.so include/Tool.h lib/
 	cp UserTools/*/*.h include/
 	g++ $(CXXFLAGS) -shared UserTools/*/*.o -I include -L lib -lStore -lDataModel -lLogging -o lib/libMyTools.so $(MyToolsInclude) $(DataModelInclude) $(MyToolsLib)
 
-lib/libLogging.so:  $(Dependancies)/ToolFrameworkCore/src/Logging/* | lib/libStore.so
-	cd $(Dependancies)/ToolFrameworkCore && $(MAKE) lib/libLogging.so
+lib/libLogging.so:  $(Dependencies)/ToolFrameworkCore/src/Logging/* | lib/libStore.so
+	cd $(Dependencies)/ToolFrameworkCore && $(MAKE) lib/libLogging.so
 	@echo -e "\e[38;5;118m\n*************** Copying " $@ "****************\e[0m"
-	cp $(Dependancies)/ToolFrameworkCore/src/Logging/Logging.h include/
-	cp $(Dependancies)/ToolFrameworkCore/lib/libLogging.so lib/
+	cp $(Dependencies)/ToolFrameworkCore/src/Logging/Logging.h include/
+	cp $(Dependencies)/ToolFrameworkCore/lib/libLogging.so lib/
 
 UserTools/%.o: UserTools/%.cpp lib/libStore.so include/Tool.h lib/libLogging.so lib/libDataModel.so
 	@echo -e "\e[38;5;214m\n*************** Making " $@ "****************\e[0m"

--- a/Setup.sh
+++ b/Setup.sh
@@ -2,8 +2,8 @@
 
 #Application path location of applicaiton
 
-Dependancies=`pwd`/Dependancies
+Dependencies=`pwd`/Dependencies
 
-export LD_LIBRARY_PATH=`pwd`/lib:${Dependancies}/ToolFramework/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=`pwd`/lib:${Dependencies}/ToolFramework/lib:$LD_LIBRARY_PATH
 
 export SEGFAULT_SIGNALS="all"


### PR DESCRIPTION
rename Dependancies to Dependencies in GetToolFramework.sh
Update Makefile, and Setup files accordingly.

Bonus: add a .gitignore.